### PR TITLE
Removes build of bigbluebutton-web

### DIFF
--- a/docker/assets/setup.sh
+++ b/docker/assets/setup.sh
@@ -111,10 +111,6 @@ su bigbluebutton -c bash -l << 'EOF'
     cd bbb-common-web/
     ./deploy.sh
     cd ..
-
-    cd bigbluebutton-web/
-    ./build.sh || true
-    cd ..
      
     cd bigbluebutton-html5/
     npm install


### PR DESCRIPTION
For some reason the `setup.sh` finishes after run `./build.sh || true`.
Removing it temporarily.