### PR TITLE
Fix: error on nginx starting(related to locale html5client/compatibility/)

### DIFF
--- a/docker/assets/rc.local
+++ b/docker/assets/rc.local
@@ -37,7 +37,7 @@ sudo sed -i '/^location \/html5client\/fonts/,+2 s/^/#/' /usr/share/bigbluebutto
 cat /usr/share/bigbluebutton/nginx/bbb-html5.nginx  | grep "for production" -v > /tmp/bbb-html5.nginx ; cat /tmp/bbb-html5.nginx > /usr/share/bigbluebutton/nginx/bbb-html5.nginx ; rm /tmp/bbb-html5.nginx
 cat /usr/share/bigbluebutton/nginx/bbb-html5.nginx | sed 's|# proxy_pass http://127.0.0.1:4100; # use for development|proxy_pass http://127.0.0.1:4100; # use for development|g' > /tmp/bbb-html5.nginx ; cat /tmp/bbb-html5.nginx > /usr/share/bigbluebutton/nginx/bbb-html5.nginx ; rm /tmp/bbb-html5.nginx
 systemctl enable nginx
-systemctl start nginx
+systemctl restart nginx
 
 systemctl enable tomcat9
 systemctl start tomcat9

--- a/docker/assets/rc.local
+++ b/docker/assets/rc.local
@@ -27,11 +27,11 @@ if [ -f /local/certs/bbb-dev-ca.crt ]; then
 fi;
 
 #Switch NginX static resource requests to Meteor
-sudo sed -i '/\/html5client\/locales/,+2 s/^/#/' /usr/share/bigbluebutton/nginx/bbb-html5.nginx
-sudo sed -i '/\/html5client\/compatibility/,+2 s/^/#/' /usr/share/bigbluebutton/nginx/bbb-html5.nginx
-sudo sed -i '/\/html5client\/resources/,+2 s/^/#/' /usr/share/bigbluebutton/nginx/bbb-html5.nginx
-sudo sed -i '/\/html5client\/svgs/,+2 s/^/#/' /usr/share/bigbluebutton/nginx/bbb-html5.nginx
-sudo sed -i '/\/html5client\/fonts/,+2 s/^/#/' /usr/share/bigbluebutton/nginx/bbb-html5.nginx
+sudo sed -i '/^location \/html5client\/locales/,+2 s/^/#/' /usr/share/bigbluebutton/nginx/bbb-html5.nginx
+sudo sed -i '/^location \/html5client\/compatibility/,+3 s/^/#/' /usr/share/bigbluebutton/nginx/bbb-html5.nginx
+sudo sed -i '/^location \/html5client\/resources/,+2 s/^/#/' /usr/share/bigbluebutton/nginx/bbb-html5.nginx
+sudo sed -i '/^location \/html5client\/svgs/,+2 s/^/#/' /usr/share/bigbluebutton/nginx/bbb-html5.nginx
+sudo sed -i '/^location \/html5client\/fonts/,+2 s/^/#/' /usr/share/bigbluebutton/nginx/bbb-html5.nginx
 
 # https://docs.bigbluebutton.org/2.4/dev.html#switch-nginx-to-redirect-requests-to-meteor 
 cat /usr/share/bigbluebutton/nginx/bbb-html5.nginx  | grep "for production" -v > /tmp/bbb-html5.nginx ; cat /tmp/bbb-html5.nginx > /usr/share/bigbluebutton/nginx/bbb-html5.nginx ; rm /tmp/bbb-html5.nginx


### PR DESCRIPTION
- Fix problem on commenting `locale html5client/compatibility/` in `/usr/share/bigbluebutton/nginx/bbb-html5.nginx` since now it has 4 lines instead of 3.
- Avoid comment lines that is already commented