### PR TITLE
Set CI resource_class to large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   build:
     machine:
       image: ubuntu-2004:2022.04.2
+    resource_class: large
     steps:
       - checkout
       - run: |


### PR DESCRIPTION
Likely fix: `bbb-install: Your server needs to have (at least) 4 CPUs (8 recommended for production).`