### PR TITLE
Copy certs to haproxy

### DIFF
--- a/docker/assets/rc.local
+++ b/docker/assets/rc.local
@@ -8,6 +8,16 @@ rm -rf /etc/letsencrypt
 mkdir /etc/letsencrypt/live/`hostname -f` -p
 mount --bind /local/certs/ /etc/letsencrypt/live/`hostname -f`
 
+
+# now haproxy serve port 443, and it expects the cert in /etc/haproxy/certbundle.pem
+#copied from https://github.com/bigbluebutton/bbb-install/blob/16825846cb230ead230f00c9d3064b8d6dcee0bf/bbb-install-2.6.sh#L761
+cat "/etc/letsencrypt/live/${THIS_HOST}"/{fullchain,privkey}.pem > /tmp/certbundle.pem.new
+chown root:haproxy /tmp/certbundle.pem.new
+chmod 0640 /tmp/certbundle.pem.new
+mv /tmp/certbundle.pem.new /etc/haproxy/certbundle.pem
+systemctl reload haproxy
+
+
 if [ "$BBB_HOST" != "$THIS_HOST" ] ; then
     sed -i 's/'$BBB_HOST'/'$THIS_HOST'/g' /etc/nginx/sites-available/bigbluebutton
     sed -i 's/'$BBB_HOST'/'$THIS_HOST'/g' /usr/share/bigbluebutton/nginx/sip.nginx


### PR DESCRIPTION
It's required now that Haproxy read certs from `/etc/haproxy/certbundle.pem`

https://github.com/bigbluebutton/bbb-install/blob/16825846cb230ead230f00c9d3064b8d6dcee0bf/bbb-install-2.6.sh#L761