### PR TITLE
Tweaks for BBB 2.8 on Ubuntu 22.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:20.04
-MAINTAINER ffdixon@bigbluebutton.org
+FROM ubuntu:22.04
+LABEL authors="Fred Dixon, Anton Georgiev"
 
 #Force rebuild - 26.11.2021 
 
@@ -12,15 +12,15 @@ RUN apt install -y language-pack-en
 RUN update-locale LANG=en_US.UTF-8
 RUN apt install -y --no-install-recommends apt-utils
 RUN apt install -y wget software-properties-common
-RUN apt install -y mlocate strace iputils-ping telnet tcpdump vim htop
+RUN apt install -y plocate strace iputils-ping telnet tcpdump vim htop
 
 # -- Anticipate docker user and group creation (for ubuntu 22 docker-in-docker compatibility)
 RUN groupadd -o -g 999 docker
 
 # -- Install yq 
-# RUN LC_CTYPE=C.UTF-8 add-apt-repository ppa:rmescandon/yq
-# RUN apt update
-# RUN LC_CTYPE=C.UTF-8 apt install yq -y
+RUN LC_CTYPE=C.UTF-8 add-apt-repository ppa:rmescandon/yq
+RUN apt update
+RUN LC_CTYPE=C.UTF-8 apt install yq -y
 
 RUN apt-get install -y \
   haveged    \
@@ -42,7 +42,7 @@ RUN systemctl disable systemd-update-utmp.service
 #    Add a number there to force update files
 ADD assets/nocache /root
 RUN mkdir /opt/docker-bbb/
-RUN wget https://raw.githubusercontent.com/bigbluebutton/bbb-install/v2.7.x-release/bbb-install.sh -O- | sed 's|https://\$PACKAGE_REPOSITORY|http://\$PACKAGE_REPOSITORY|g' > /opt/docker-bbb/bbb-install.sh
+RUN wget https://raw.githubusercontent.com/bigbluebutton/bbb-install/v2.8.x-release/bbb-install.sh -O- | sed 's|https://\$PACKAGE_REPOSITORY|http://\$PACKAGE_REPOSITORY|g' > /opt/docker-bbb/bbb-install.sh
 
 RUN chmod 755 /opt/docker-bbb/bbb-install.sh
 ADD ./assets/setup.sh /opt/docker-bbb/setup.sh


### PR DESCRIPTION
- BBB 2.8 runs on Ubuntu 22.04
- `yq` is again used from upstream (upgraded to version ~4.16 provided as a jammy package by rmescandon)
- `mlocate` is replaced by `plocate` on Ubuntu 22.04
- updated the bbb-install command
- MAINTAINER has been deprecated, replaced by LABEL. I added my name too :stuck_out_tongue_closed_eyes: . One more PR coming with some refactoring