### PR TITLE
Use bbb-install sh from Github

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN systemctl disable systemd-update-utmp.service
 ADD assets/nocache /root
 RUN mkdir /opt/docker-bbb/
 # RUN wget https://ubuntu.bigbluebutton.org/bbb-install-25.sh -O- | sed 's|https://\$PACKAGE_REPOSITORY|http://\$PACKAGE_REPOSITORY|g' > /opt/docker-bbb/bbb-install.sh
-RUN wget https://ubuntu.bigbluebutton.org/bbb-install-2.6.sh -O- | sed 's|https://\$PACKAGE_REPOSITORY|http://\$PACKAGE_REPOSITORY|g' > /opt/docker-bbb/bbb-install.sh
+RUN wget https://raw.githubusercontent.com/bigbluebutton/bbb-install/master/bbb-install-2.6.sh -O- | sed 's|https://\$PACKAGE_REPOSITORY|http://\$PACKAGE_REPOSITORY|g' > /opt/docker-bbb/bbb-install.sh
 
 RUN chmod 755 /opt/docker-bbb/bbb-install.sh
 ADD ./assets/setup.sh /opt/docker-bbb/setup.sh


### PR DESCRIPTION
Tweak bbb-install.sh to get it from https://github.com/bigbluebutton/bbb-install
Once the dev-docker uses development packages, it should use the script from Github instead of the oficial script which depends on a new release to be updated.

It will fix the current error in 2.6 build:
![image](https://github.com/iMDT/bbb-docker-dev-build/assets/5660191/57c51855-d3f1-4e9a-a232-74dfab29ea70)

