### PR TITLE
refactor: Remove phase that builds sbt and npm caches

### DIFF
--- a/docker/assets/setup.sh
+++ b/docker/assets/setup.sh
@@ -163,29 +163,29 @@ su bigbluebutton -c bash -l << 'EOF'
     ' >> $HOME/.zshrc
 
     # Build source artifacts ( to have dependencies cached )
-    cd ~
-    git clone --single-branch --branch v2.7.x-release https://github.com/bigbluebutton/bigbluebutton.git
+    #cd ~
+    #git clone --single-branch --branch v3.0.x-release https://github.com/bigbluebutton/bigbluebutton.git
     #git clone --single-branch --branch develop https://github.com/bigbluebutton/bigbluebutton.git
-     
-    cd bigbluebutton
-     
-    cd bbb-common-message/
-    ./deploy.sh
-    cd ..
-     
-    cd bbb-common-web/
-    ./deploy.sh
-    cd ..
-
-    cd bigbluebutton-web/
-    ./build.sh </dev/null
-    cd ..
     
-    cd bigbluebutton-html5/
-    npm install
-    cd ..
+    #cd bigbluebutton
+     
+    #cd bbb-common-message/
+    #./deploy.sh
+    #cd ..
+     
+    #cd bbb-common-web/
+    #./deploy.sh
+    #cd ..
 
-    rm -rf ~/bigbluebutton/
+    #cd bigbluebutton-web/
+    #./build.sh </dev/null
+    #cd ..
+    
+    #cd bigbluebutton-html5/
+    #npm install
+    #cd ..
+
+    #rm -rf ~/bigbluebutton/
 EOF
 
 


### PR DESCRIPTION
The cache for `bbb-common-message` and `bbb-common-web` are not being used because now the docker-dev shares the `$HOME/.m2` and `$HOME/.ivy2` with the host machine: https://github.com/bigbluebutton/docker-dev/blob/b8ccd13544076b3ad38014ab62cd9f0c667f2aae/create_bbb.sh#L274C534-L274C545

And the utility of caching for HTML5 is questionable. While it may increase the size of the Docker image, it doesn't significantly reduce the time taken for the `meteor npm i` command.