### PR TITLE
Create sbt dirs to set bigbluebutton as owner

### DIFF
--- a/docker/assets/setup.sh
+++ b/docker/assets/setup.sh
@@ -162,6 +162,10 @@ su bigbluebutton -c bash -l << 'EOF'
          source "$HOME/.sdkman/bin/sdkman-init.sh"
     ' >> $HOME/.zshrc
 
+    # Create sbt directories to set bigbluebutton as owner
+    mkdir $HOME/.ivy2
+    mkdir $HOME/.m2
+
     # Build source artifacts ( to have dependencies cached )
     #cd ~
     #git clone --single-branch --branch v3.0.x-release https://github.com/bigbluebutton/bigbluebutton.git


### PR DESCRIPTION
It will avoid permission problems when building common-msg.

```
mkdir $HOME/.ivy2
mkdir $HOME/.m2
``` 