### PR TITLE
Create symlink of bbb-html5/settings.yml to /usr/share

### DIFF
--- a/docker/assets/rc.local
+++ b/docker/assets/rc.local
@@ -83,6 +83,11 @@ sudo yq e -i ".public.pads.url = \"https://$(hostname -f)/pad\"" /etc/bigbluebut
 sudo yq e -i ".public.kurento.wsUrl = \"wss://$(hostname -f)/bbb-webrtc-sfu\"" /etc/bigbluebutton/bbb-html5.yml
 [ "$BBBHTML5_CONFIG_PREV_CONTENT" != "$(cat /etc/bigbluebutton/bbb-html5.yml)" ] && sudo systemctl restart bbb-html5
 
+#html5: make akka-apps read the same settings.yml of bbb-html5 project (using symlink)
+if [ -f /home/bigbluebutton/src/bigbluebutton-html5/private/config/settings.yml ]; then
+  sudo ln -sfn /home/bigbluebutton/src/bigbluebutton-html5/private/config/settings.yml /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
+fi
+
 #bbb-web: set securitySalt
 
 BBBWEB_CONFIG_PREV_CONTENT=$(cat /etc/bigbluebutton/bbb-web.properties)

--- a/docker/assets/setup.sh
+++ b/docker/assets/setup.sh
@@ -69,7 +69,6 @@ sudo sed -i '/^location \/html5client\/fonts/,+2 s/^/#/' /usr/share/bigbluebutto
 sudo touch /etc/bigbluebutton/bbb-html5.yml;
 
 #html5: set audio via http
-sudo yq e -i '.public.media.sipjsHackViaWs = true' /usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml
 sudo yq e -i '.public.media.sipjsHackViaWs = true' /etc/bigbluebutton/bbb-html5.yml
 
 #Enable Hasura console


### PR DESCRIPTION
Once `clientSettings` is now provided through Graphql.

Problem:
- `Akka-apps` read  `settings.yml` from `/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml`.
- Meteor ( `npm start`) read from `/home/bigbluebutton/src/bigbluebutton-html5/private/config/settings.yml`.

So any change in `settings.yml` should be made in both files to take affect.
But it is hard to remember that it needs to be changed in both places.

In order to avoid this problem, this PR will make the dev-docker automatically link:
`/usr/share/meteor/bundle/programs/server/assets/app/config/settings.yml` 
as a symlink of:
 `/home/bigbluebutton/src/bigbluebutton-html5/private/config/settings.yml`.

This way both files will be always the equal.