### PR TITLE
Install the 4 extra playback format packages at image build time

### DIFF
--- a/docker/assets/setup.sh
+++ b/docker/assets/setup.sh
@@ -56,6 +56,13 @@ sudo apt install -y rsyslog
 # [ -f /etc/systemd/system/syslog.service ] || sudo ln -s /lib/systemd/system/rsyslog.service /etc/systemd/system/syslog.service
 
 ./bbb-install.sh -d -s "`hostname -f`" -v jammy-30-dev-branch
+
+# Install the 4 extra playback format packages (presentation is already installed by bbb-install).
+# Installed here (image build time, apt is healthy) so every container is born with all 5 formats
+# available. NOT activated in recording.yml - activation is opt-in by whoever needs it
+# (processing 5 formats costs minutes of CPU per recording; default stays presentation-only).
+apt install -y bbb-playback-notes bbb-playback-screenshare bbb-playback-podcast bbb-playback-video
+
 sed -i 's/::/0.0.0.0/g' /opt/freeswitch/etc/freeswitch/autoload_configs/event_socket.conf.xml
 
 # Change the nginx lines


### PR DESCRIPTION
## What

In `docker/assets/setup.sh`, right after `bbb-install.sh` runs, install the 4 extra recording playback format packages:

```
apt install -y bbb-playback-notes bbb-playback-screenshare bbb-playback-podcast bbb-playback-video
```

The `presentation` format is already pulled in by `bbb-install.sh`, so only the 4 additional formats are installed here. That gives every container born from this image all 5 playback formats available. This mirrors the existing `# Install optional packages` idiom already used on this branch for `bbb-shared-notes-server` and `bbb-livekit`.

## Why

Installing the playback packages at image build time (right after the packaged `bbb-install.sh`) is done while apt is in a pure packaged state. Doing it here means the container ships all 5 formats without ever hitting the metapackage `bigbluebutton` vs from-source akka stub conflict at container runtime, so the recording flow never crosses that conflict.

## Not activated by default (intentional)

The formats are installed but NOT activated in `recording.yml`. Activation stays opt-in for whoever needs it: processing 5 formats costs minutes of CPU per recording, so the default stays presentation-only. No `recording.yml` change is part of this PR.

## Validation

- Confirmed all 4 packages exist in the exact apt repo this branch's build configures. `bbb-install.sh` (fetched from `bigbluebutton/bbb-install@v3.0.x-release`, as pinned in `docker/Dockerfile`) with `-v jammy-30-dev-branch` configures `deb https://ubuntu.bigbluebutton.org/jammy-30-dev-branch bigbluebutton-jammy main`.
- Queried that repo's `Packages` index (`dists/bigbluebutton-jammy/main/binary-amd64/Packages.gz`, HTTP 200) and found all 4 packages (plus `bbb-playback-presentation`): notes `1:3.0-3`, screenshare `1:3.0-4`, podcast `1:3.0-4`, video `1:3.0-3`.
- `bash -n docker/assets/setup.sh` passes (syntax OK).
- Not validated: a full end-to-end image build was not run (out of scope for the requested minimal validation).
